### PR TITLE
Feature/camera lerp synchroniser

### DIFF
--- a/example/bindings/tab-navigation.ts
+++ b/example/bindings/tab-navigation.ts
@@ -2,7 +2,7 @@ import { Mesh, Object3D } from "three";
 
 import { IDataStore } from "@studiohyperdrive/interactive-map/dist/data-store/data-store.types";
 import { ITabNavigationBindingConfig } from "@studiohyperdrive/interactive-map/dist/plugins";
-import { zoomCameraToSelection, mutateRandomColor, setCameraToConfig } from "@studiohyperdrive/interactive-map/dist/utils";
+import { zoomCameraToSelection, mutateRandomColor, zoomCameraToConfig } from "@studiohyperdrive/interactive-map/dist/utils";
 
 import { ortho, ortho2 } from "../config/sceneConfig";
 import { BindingCallback } from "@studiohyperdrive/interactive-map/dist/types";
@@ -24,7 +24,7 @@ export const resetCamera: BindingCallback = (
     object: Object3D | null,
     datastore: IDataStore
 ) => {
-    setCameraToConfig(datastore, ortho2.camera.config);
+    zoomCameraToConfig(datastore, ortho2.camera.config);
 }
 
 export function createTabNavigationBindings(): ITabNavigationBindingConfig[] {

--- a/example/components/webgl/webgl.tsx
+++ b/example/components/webgl/webgl.tsx
@@ -21,6 +21,7 @@ import {
   MapControlsPlugin,
   IlluminationPlugin,
   WebglRendererPlugin,
+  CameraLerpSynchroniserPlugin,
 } from "@studiohyperdrive/interactive-map/dist/plugins";
 import { getChildren, hideChild, showChild } from "@studiohyperdrive/interactive-map/dist/utils";
 
@@ -58,31 +59,34 @@ const WebGL: FC<WebGLProps> = ({ three, disabled }) => {
   }
 
   const buildThree = (): ThreeEntryPoint | null => {
-    return threeRootElement.current
-      ? new ThreeEntryPoint(
-        threeRootElement.current,
-        ortho2,
-        [
-          new BrowserResizePlugin(window),
-          new MousePositionPlugin(),
-          new RaycasterPlugin({ trigger: "mousemove" }),
-          new ClickPlugin(createClickBindings(store, router)),
-          new HoverPlugin(createHoverBindings(store)),
-          new TabNavigationPlugin(createTabNavigationBindings(), resetCamera, resetCamera),
-        ],
-        [
-          new GltfDracoLoaderPlugin("/models/interactive-map_v2.8-draco.glb", (scene: Scene) => hideCheckmarks(scene)),
-          new GlobalIlluminationPlugin(),
-          new IlluminationPlugin(illuminationConfig),
-          new ClockPlugin(),
-          new AnimationMixerPlugin(),
-          new AnimationPlugin(animationConfig),
-          new MapControlsPlugin(controlsConfig),
-          new CameraLerpPlugin(2),
-          new WebglRendererPlugin(rendererConfig)
-        ]
-      )
-      : null;
+    if (!threeRootElement.current) {
+      return null;
+    }
+
+    return new ThreeEntryPoint(
+      threeRootElement.current,
+      ortho2,
+      [
+        new BrowserResizePlugin(window),
+        new MousePositionPlugin(),
+        new RaycasterPlugin({ trigger: "mousemove" }),
+        new ClickPlugin(createClickBindings(store, router)),
+        new HoverPlugin(createHoverBindings(store)),
+        new TabNavigationPlugin(createTabNavigationBindings(), resetCamera, resetCamera),
+      ],
+      [
+        new GltfDracoLoaderPlugin("/models/interactive-map_v2.8-draco.glb", (scene: Scene) => hideCheckmarks(scene)),
+        new GlobalIlluminationPlugin(),
+        new IlluminationPlugin(illuminationConfig),
+        new ClockPlugin(),
+        new AnimationMixerPlugin(),
+        new AnimationPlugin(animationConfig),
+        new MapControlsPlugin(controlsConfig),
+        new CameraLerpPlugin(2),
+        new WebglRendererPlugin(rendererConfig),
+        new CameraLerpSynchroniserPlugin(),
+      ]
+    );
   };
 
   // Run once

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -567,9 +567,9 @@
       "dev": true
     },
     "@studiohyperdrive/interactive-map": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@studiohyperdrive/interactive-map/-/interactive-map-2.9.0.tgz",
-      "integrity": "sha512-wuaO5t1TrjNPBa5zdrl5kjIN0KvPlTWLQIAM9S9iIPMzw44VgIZrBeyi2QhQTGfZYite7hHyzRcl/L0nQCtQLg==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@studiohyperdrive/interactive-map/-/interactive-map-2.9.1.tgz",
+      "integrity": "sha512-9U5MsbgsSU1lXp/3ihbsip7T3tgAJdzj8qohuMeBrWGTKaLSCUz+2c6d2W1cRCQ+jTLTJ6Ww+aEZ6flsvzoJGw==",
       "requires": {
         "three": "^0.132.2"
       }

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -567,9 +567,9 @@
       "dev": true
     },
     "@studiohyperdrive/interactive-map": {
-      "version": "2.8.6",
-      "resolved": "https://registry.npmjs.org/@studiohyperdrive/interactive-map/-/interactive-map-2.8.6.tgz",
-      "integrity": "sha512-lYhsIjWnXZ60eOJ9V6du63lITMrS9hyuRpdkvOOST+q6+ubrFF4FGCsIi4b4amKTVtow9CvJDSGN0serHKsjNQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@studiohyperdrive/interactive-map/-/interactive-map-2.9.0.tgz",
+      "integrity": "sha512-wuaO5t1TrjNPBa5zdrl5kjIN0KvPlTWLQIAM9S9iIPMzw44VgIZrBeyi2QhQTGfZYite7hHyzRcl/L0nQCtQLg==",
       "requires": {
         "three": "^0.132.2"
       }

--- a/example/package.json
+++ b/example/package.json
@@ -15,7 +15,7 @@
     "@emotion/styled": "^11.3.0",
     "@mui/material": "^5.0.0",
     "@reduxjs/toolkit": "^1.6.1",
-    "@studiohyperdrive/interactive-map": "^2.9.0",
+    "@studiohyperdrive/interactive-map": "^2.9.1",
     "next": "11.1.2",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/example/package.json
+++ b/example/package.json
@@ -15,7 +15,7 @@
     "@emotion/styled": "^11.3.0",
     "@mui/material": "^5.0.0",
     "@reduxjs/toolkit": "^1.6.1",
-    "@studiohyperdrive/interactive-map": "^2.8.6",
+    "@studiohyperdrive/interactive-map": "^2.9.0",
     "next": "11.1.2",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/package/package-lock.json
+++ b/package/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiohyperdrive/interactive-map",
-  "version": "2.8.6",
+  "version": "2.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package/package-lock.json
+++ b/package/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiohyperdrive/interactive-map",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiohyperdrive/interactive-map",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "A package aimed at simplifying common three.js setups for interactive maps.",
   "type": "module",
   "main": "dist/index.js",

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiohyperdrive/interactive-map",
-  "version": "2.8.6",
+  "version": "2.9.0",
   "description": "A package aimed at simplifying common three.js setups for interactive maps.",
   "type": "module",
   "main": "dist/index.js",

--- a/package/plugins/camera-lerp-plugin/camera-lerp-plugin.helpers.ts
+++ b/package/plugins/camera-lerp-plugin/camera-lerp-plugin.helpers.ts
@@ -1,0 +1,17 @@
+import { ICameraLerpPlugin } from "./camera-lerp-plugin.types";
+
+export const getCameraLerpPlugin = (plugins: any[]): ICameraLerpPlugin | undefined => {
+    return plugins.find(plugin => isCameraLerpPlugin(plugin));
+}
+
+/**
+ * Based on:
+ * - https://stackoverflow.com/a/43922291
+ * - https://stackoverflow.com/a/33733258
+ * @param object The object to check
+ * @returns boolean
+ */
+export const isCameraLerpPlugin = (object: any): object is ICameraLerpPlugin => {
+    const properties = ['camera', 'controls', 'isAnimating'];
+    return properties.every(prop => prop in object);
+}

--- a/package/plugins/camera-lerp-plugin/camera-lerp-plugin.ts
+++ b/package/plugins/camera-lerp-plugin/camera-lerp-plugin.ts
@@ -52,15 +52,21 @@ export class CameraLerpPlugin {
                         // Animate orthographic zoom level
                         if (this.camera instanceof OrthographicCamera) {
                             const bSphere = zoomProps.boundingBox.getBoundingSphere(new Sphere(target));
-                            const zoom = MathUtils.lerp(this.camera.top, bSphere.radius * zoomProps.fitRatio, delta * speed);
+                            const zoom = MathUtils.lerp(
+                                this.camera.top,
+                                zoomProps.frustum
+                                    ? zoomProps.frustum / 2
+                                    : bSphere.radius * zoomProps.fitRatio,
+                                delta * speed
+                            );
 
+                            this.camera.left = - zoom * zoomProps.aspect;
+                            this.camera.right = zoom * zoomProps.aspect;
                             this.camera.top = zoom;
                             this.camera.bottom = - zoom;
-                            this.camera.right = zoom * zoomProps.aspect;
-                            this.camera.left = - zoom * zoomProps.aspect;
                         }
 
-                        if (this.controls.target.distanceTo(target) > 0.01) {
+                        if (this.controls.target.distanceTo(target) > 0.001) {
                             // Animate orbitcontrols focus point
                             this.controls.target.lerp(target, delta * speed);
 
@@ -69,6 +75,8 @@ export class CameraLerpPlugin {
                             this.controls.update();
 
                             this.camera.updateProjectionMatrix();
+
+                            console.info('cycle');
                         } else {
                             this.animating = false;
                         }

--- a/package/plugins/camera-lerp-plugin/camera-lerp-plugin.ts
+++ b/package/plugins/camera-lerp-plugin/camera-lerp-plugin.ts
@@ -1,8 +1,8 @@
 import { OrthographicCamera, PerspectiveCamera, Sphere, Vector3, MathUtils, Box3 } from "three";
 import { MapControls } from "three/examples/jsm/controls/OrbitControls";
 
-import { IDataStore } from "../../data-store/data-store.types";
 import constants from "../../constants";
+import { IDataStore } from "../../data-store/data-store.types";
 
 import { ICameraLerpPlugin } from "./camera-lerp-plugin.types";
 
@@ -13,8 +13,8 @@ export class CameraLerpPlugin {
             private currentTarget: Box3 | undefined;
             private animating: boolean;
 
-            public controls: MapControls;
             public camera: PerspectiveCamera | OrthographicCamera;
+            public controls: MapControls;
 
             constructor(dataStore: IDataStore) {
                 this.dataStore = dataStore;
@@ -76,7 +76,7 @@ export class CameraLerpPlugin {
 
                 }
             }
-        }
+        };
     }
 }
 

--- a/package/plugins/camera-lerp-plugin/camera-lerp-plugin.ts
+++ b/package/plugins/camera-lerp-plugin/camera-lerp-plugin.ts
@@ -26,6 +26,10 @@ export class CameraLerpPlugin {
                 this.camera = this.dataStore.get(constants.store.camera);
             }
 
+            public isAnimating(): boolean {
+                return this.animating;
+            }
+
             public update() {
                 const zoomProps = this.dataStore.get(constants.store.zoomProps);
 

--- a/package/plugins/camera-lerp-plugin/camera-lerp-plugin.ts
+++ b/package/plugins/camera-lerp-plugin/camera-lerp-plugin.ts
@@ -10,11 +10,11 @@ export class CameraLerpPlugin {
     constructor(speed: number) {
         return class implements ICameraLerpPlugin {
             private dataStore: IDataStore;
-            private currentTarget: Box3 | undefined;
+            private currentTarget: Box3 | undefined;
             private animating: boolean;
 
             public controls: MapControls;
-            public camera: PerspectiveCamera | OrthographicCamera;
+            public camera: PerspectiveCamera | OrthographicCamera;
 
             constructor(dataStore: IDataStore) {
                 this.dataStore = dataStore;
@@ -30,7 +30,7 @@ export class CameraLerpPlugin {
                 const zoomProps = this.dataStore.get(constants.store.zoomProps);
 
                 if (zoomProps) { // Only exists when zoomCameraToSelection util is fired at least once
-                    if (this.currentTarget !== zoomProps.boundingBox || this.animating) { // Only animate towards new objects or keep animating if not finished
+                    if (this.currentTarget !== zoomProps.boundingBox || this.animating) { // Only animate towards new objects or keep animating if not finished
                         if (this.currentTarget !== zoomProps.boundingBox) {
                             this.currentTarget = zoomProps.boundingBox;
                             this.animating = true;
@@ -42,20 +42,9 @@ export class CameraLerpPlugin {
                         // Fetch fresh instances
                         this.controls = this.dataStore.get(constants.store.controls);
                         this.camera = this.dataStore.get(constants.store.camera);
-                        
-                        const delta = this.dataStore.get(constants.store.deltaTime);
-    
-                        if (this.controls.target.distanceTo(target) > 0.01) {
-                            // Animate orbitcontrols focus point
-                            this.controls.target.lerp(target, delta * speed);
 
-                            // Animate camera position
-                            this.camera.position.lerp((target.sub(zoomProps.direction)), delta * speed);
-                            this.controls.update();
-                        } else {
-                            this.animating = false;
-                        }
-        
+                        const delta = this.dataStore.get(constants.store.deltaTime);
+
                         // Animate orthographic zoom level
                         if (this.camera instanceof OrthographicCamera) {
                             const bSphere = zoomProps.boundingBox.getBoundingSphere(new Sphere(target));
@@ -67,9 +56,20 @@ export class CameraLerpPlugin {
                             this.camera.left = - zoom * zoomProps.aspect;
                         }
 
-                        this.camera.updateProjectionMatrix();
+                        if (this.controls.target.distanceTo(target) > 0.01) {
+                            // Animate orbitcontrols focus point
+                            this.controls.target.lerp(target, delta * speed);
+
+                            // Animate camera position
+                            this.camera.position.lerp((target.sub(zoomProps.direction)), delta * speed);
+                            this.controls.update();
+
+                            this.camera.updateProjectionMatrix();
+                        } else {
+                            this.animating = false;
+                        }
                     }
-                    
+
                 }
             }
         }

--- a/package/plugins/camera-lerp-plugin/camera-lerp-plugin.types.ts
+++ b/package/plugins/camera-lerp-plugin/camera-lerp-plugin.types.ts
@@ -1,7 +1,10 @@
+import { OrthographicCamera, PerspectiveCamera } from "three";
 import { MapControls } from "three/examples/jsm/controls/OrbitControls";
 
 import { IScenePlugin } from "../../types";
 
 export interface ICameraLerpPlugin extends IScenePlugin {
-    controls: MapControls
+    controls: MapControls;
+    camera: PerspectiveCamera | OrthographicCamera;
+    isAnimating: () => boolean;
 }

--- a/package/plugins/camera-lerp-plugin/camera-lerp-plugin.types.ts
+++ b/package/plugins/camera-lerp-plugin/camera-lerp-plugin.types.ts
@@ -4,7 +4,7 @@ import { MapControls } from "three/examples/jsm/controls/OrbitControls";
 import { IScenePlugin } from "../../types";
 
 export interface ICameraLerpPlugin extends IScenePlugin {
-    controls: MapControls;
     camera: PerspectiveCamera | OrthographicCamera;
+    controls: MapControls;
     isAnimating: () => boolean;
 }

--- a/package/plugins/camera-lerp-synchroniser-plugin/camera-lerp-synchroniser-plugin.helpers.ts
+++ b/package/plugins/camera-lerp-synchroniser-plugin/camera-lerp-synchroniser-plugin.helpers.ts
@@ -1,0 +1,17 @@
+import { ICameraLerpSynchroniserPlugin } from "./camera-lerp-synchroniser-plugin.types";
+
+export const getCameraLerpSynchroniserPlugin = (plugins: any[]): ICameraLerpSynchroniserPlugin | undefined => {
+    return plugins.find(plugin => isCameraLerpSynchroniserPlugin(plugin));
+}
+
+/**
+ * Based on:
+ * - https://stackoverflow.com/a/43922291
+ * - https://stackoverflow.com/a/33733258
+ * @param object The object to check
+ * @returns boolean
+ */
+export const isCameraLerpSynchroniserPlugin = (object: any): object is ICameraLerpSynchroniserPlugin => {
+    const properties = ['lerp', 'raycaster', 'hover', 'update'];
+    return properties.every(prop => prop in object);
+}

--- a/package/plugins/camera-lerp-synchroniser-plugin/camera-lerp-synchroniser-plugin.ts
+++ b/package/plugins/camera-lerp-synchroniser-plugin/camera-lerp-synchroniser-plugin.ts
@@ -1,0 +1,43 @@
+import { ICameraLerpPlugin, IHoverPlugin, IRaycasterPlugin } from "..";
+
+import { IDataStore } from "../../data-store/data-store.types";
+
+import { ICameraLerpSynchroniserPlugin } from "./camera-lerp-synchroniser-plugin.types";
+
+/**
+ * This plugin will be detected by ThreeEntryPoint at construct-time and will look for the instances of the plugins it aims to "glue" together
+ */
+export class CameraLerpSynchroniserPlugin {
+    constructor(
+        lerp?: ICameraLerpPlugin,
+        raycaster?: IRaycasterPlugin,
+        hover?: IHoverPlugin
+    ) {
+        return class implements ICameraLerpSynchroniserPlugin {
+            private dataStore: IDataStore;
+
+            public lerp: ICameraLerpPlugin | undefined = lerp;
+            public raycaster: IRaycasterPlugin | undefined = raycaster;
+            public hover: IHoverPlugin | undefined = hover;
+
+            constructor(dataStore: IDataStore) {
+                this.dataStore = dataStore;
+            }
+
+            update() {
+                if (!this.lerp || !this.raycaster) {
+                    return;
+                }
+
+                if (this.lerp.isAnimating()) {
+                    console.info('casting & hovering');
+
+                    this.raycaster.handleCast();
+                    this.hover?.handleHover();
+                }
+            }
+        }
+    }
+}
+
+export default CameraLerpSynchroniserPlugin;

--- a/package/plugins/camera-lerp-synchroniser-plugin/camera-lerp-synchroniser-plugin.ts
+++ b/package/plugins/camera-lerp-synchroniser-plugin/camera-lerp-synchroniser-plugin.ts
@@ -30,8 +30,6 @@ export class CameraLerpSynchroniserPlugin {
                 }
 
                 if (this.lerp.isAnimating()) {
-                    console.info('casting & hovering');
-
                     this.raycaster.handleCast();
                     this.hover?.handleHover();
                 }

--- a/package/plugins/camera-lerp-synchroniser-plugin/camera-lerp-synchroniser-plugin.types.ts
+++ b/package/plugins/camera-lerp-synchroniser-plugin/camera-lerp-synchroniser-plugin.types.ts
@@ -1,0 +1,8 @@
+import { ICameraLerpPlugin, IHoverPlugin, IRaycasterPlugin } from "..";
+import { IScenePlugin } from "../../types";
+
+export interface ICameraLerpSynchroniserPlugin extends IScenePlugin {
+    lerp: ICameraLerpPlugin | undefined;
+    raycaster: IRaycasterPlugin | undefined;
+    hover: IHoverPlugin | undefined;
+}

--- a/package/plugins/hover-plugin/hover-plugin.helpers.ts
+++ b/package/plugins/hover-plugin/hover-plugin.helpers.ts
@@ -1,0 +1,17 @@
+import { IHoverPlugin } from "./hover-plugin.types";
+
+export const getHoverPlugin = (plugins: any[]): IHoverPlugin | undefined => {
+    return plugins.find(plugin => isHoverPlugin(plugin));
+}
+
+/**
+ * Based on:
+ * - https://stackoverflow.com/a/43922291
+ * - https://stackoverflow.com/a/33733258
+ * @param object The object to check
+ * @returns boolean
+ */
+export const isHoverPlugin = (object: any): object is IHoverPlugin => {
+    const properties = ['animations', 'bindings', 'hovered', 'mixer', 'handleHover'];
+    return properties.every(prop => prop in object);
+}

--- a/package/plugins/hover-plugin/hover-plugin.ts
+++ b/package/plugins/hover-plugin/hover-plugin.ts
@@ -14,10 +14,10 @@ export class HoverPlugin {
         return class implements IHoverPlugin {
             private dataStore: IDataStore;
 
-            public bindings: IHoverBindingConfig[] = bindings;
             public animations: AnimationClip[];
-            public mixer: AnimationMixer;
+            public bindings: IHoverBindingConfig[] = bindings;
             public hovered: Mesh | null = null;
+            public mixer: AnimationMixer;
 
             public listener: EventListener;
 
@@ -40,7 +40,7 @@ export class HoverPlugin {
                 window.removeEventListener("mousemove", this.listener);
             }
 
-            public handleHover = (e: MouseEvent): void => {
+            public handleHover = (e?: MouseEvent): void => {
                 const previous = this.hovered;
                 const current = this.dataStore.get(constants.store.intersection)?.object;
 

--- a/package/plugins/hover-plugin/hover-plugin.types.ts
+++ b/package/plugins/hover-plugin/hover-plugin.types.ts
@@ -2,13 +2,14 @@ import { AnimationClip, AnimationMixer, Mesh } from "three";
 import { BindingCallback, IBindingConfig, IEventPlugin } from "../../types";
 
 export interface IHoverPlugin extends IEventPlugin {
-    animations: AnimationClip[],
-    mixer: AnimationMixer,
-    hovered: Mesh | null,
-    handleHover: (e: MouseEvent) => void,
+    animations: AnimationClip[];
+    bindings: IHoverBindingConfig[];
+    hovered: Mesh | null;
+    mixer: AnimationMixer;
+    handleHover: (e?: MouseEvent) => void;
 }
 
 export interface IHoverBindingConfig extends IBindingConfig {
-    onHoverStart: BindingCallback,
-    onHoverEnd: BindingCallback,
+    onHoverStart: BindingCallback;
+    onHoverEnd: BindingCallback;
 }

--- a/package/plugins/index.ts
+++ b/package/plugins/index.ts
@@ -7,6 +7,12 @@ export * from "./animation-plugin/animation-plugin.types";
 export { default as BrowserResizePlugin } from "./browser-resize-plugin/browser-resize-plugin";
 export * from "./browser-resize-plugin/browser-resize-plugin.types";
 
+export { default as CameraLerpPlugin } from "./camera-lerp-plugin/camera-lerp-plugin";
+export * from "./camera-lerp-plugin/camera-lerp-plugin.types";
+
+export { default as CameraLerpSynchroniserPlugin } from "./camera-lerp-synchroniser-plugin/camera-lerp-synchroniser-plugin";
+export * from "./camera-lerp-synchroniser-plugin/camera-lerp-synchroniser-plugin.types";
+
 export { default as ClickPlugin } from "./click-plugin/click-plugin";
 export * from "./click-plugin/click-plugin.types";
 
@@ -36,9 +42,6 @@ export * from "./raycaster-plugin/raycaster-plugin.types";
 
 export { default as TabNavigationPlugin } from "./tab-navigation-plugin/tab-navigation-plugin";
 export * from "./tab-navigation-plugin/tab-navigation-plugin.types";
-
-export { default as CameraLerpPlugin } from "./camera-lerp-plugin/camera-lerp-plugin";
-export * from "./camera-lerp-plugin/camera-lerp-plugin.types";
 
 export { default as WebglRendererPlugin } from "./webgl-renderer-plugin/webgl-renderer-plugin";
 export * from "./webgl-renderer-plugin/webgl-renderer-plugin.types";

--- a/package/plugins/raycaster-plugin/raycaster-plugin.helpers.ts
+++ b/package/plugins/raycaster-plugin/raycaster-plugin.helpers.ts
@@ -1,0 +1,17 @@
+import { IRaycasterPlugin } from "./raycaster-plugin.types";
+
+export const getRaycasterPlugin = (plugins: any[]): IRaycasterPlugin | undefined => {
+    return plugins.find(plugin => isRaycasterPlugin(plugin));
+}
+
+/**
+ * Based on:
+ * - https://stackoverflow.com/a/43922291
+ * - https://stackoverflow.com/a/33733258
+ * @param object The object to check
+ * @returns boolean
+ */
+export const isRaycasterPlugin = (object: any): object is IRaycasterPlugin => {
+    const properties = ['raycaster', 'camera', 'scene', 'handleCast'];
+    return properties.every(prop => prop in object);
+}

--- a/package/plugins/raycaster-plugin/raycaster-plugin.ts
+++ b/package/plugins/raycaster-plugin/raycaster-plugin.ts
@@ -1,10 +1,10 @@
 import { Camera, Raycaster, Scene } from "three";
 
-import { IDataStore } from "../../data-store/data-store.types";
 import constants from "../../constants";
+import { IDataStore } from "../../data-store/data-store.types";
+import { flattenChildren } from "../../utils";
 
 import { IRaycasterPlugin, IRaycasterConfig } from "./raycaster-plugin.types";
-import { flattenChildren } from "../../utils";
 
 export class RaycasterPlugin {
     constructor(config: IRaycasterConfig) {

--- a/package/plugins/raycaster-plugin/raycaster-plugin.ts
+++ b/package/plugins/raycaster-plugin/raycaster-plugin.ts
@@ -24,7 +24,7 @@ export class RaycasterPlugin {
                 this.camera = this.dataStore.get(constants.store.camera);
                 this.scene = this.dataStore.get(constants.store.scene);
 
-                this.listener = this.handleClick.bind(this) as EventListener;
+                this.listener = this.handleCast.bind(this) as EventListener;
             }
 
             public bindEventListener() {
@@ -35,7 +35,7 @@ export class RaycasterPlugin {
                 window.removeEventListener(config.trigger, this.listener);
             }
 
-            public handleClick() {
+            public handleCast() {
                 const pos = this.dataStore.get(constants.store.mousePosition);
 
                 if (pos === undefined) {

--- a/package/plugins/raycaster-plugin/raycaster-plugin.types.ts
+++ b/package/plugins/raycaster-plugin/raycaster-plugin.types.ts
@@ -6,7 +6,7 @@ export interface IRaycasterPlugin extends IEventPlugin {
     raycaster: Raycaster,
     camera: Camera,
     scene: Scene,
-    handleClick: () => void,
+    handleCast: () => void,
 }
 
 // Config

--- a/package/scene-manager.ts
+++ b/package/scene-manager.ts
@@ -15,7 +15,7 @@ export default class SceneManager implements IManager {
 	public camera: PerspectiveCamera | OrthographicCamera;
 	public plugins: any[];
 
-	constructor(canvas: HTMLCanvasElement, sceneConfig: ISceneConfig, dataStore: DataStore, plugins: any[]) {
+	constructor(canvas: HTMLCanvasElement, sceneConfig: ISceneConfig, dataStore: DataStore, scenePlugins: any[]) {
 		this.dataStore = dataStore;
 
 		this.sizes = {
@@ -38,7 +38,7 @@ export default class SceneManager implements IManager {
 
 		this.dataStore.set(constants.store.cameraConfig, sceneConfig.camera);
 
-		this.plugins = plugins.map(Plugin => new Plugin(this.dataStore));
+		this.plugins = scenePlugins.map(Plugin => new Plugin(this.dataStore));
 	}
 
 	/**

--- a/package/three-entry-point.ts
+++ b/package/three-entry-point.ts
@@ -2,6 +2,10 @@ import SceneManager from "./scene-manager";
 import DataStore from "./data-store/data-store";
 
 import { IEntryPoint, ISceneConfig } from "./types";
+import { getCameraLerpSynchroniserPlugin } from "./plugins/camera-lerp-synchroniser-plugin/camera-lerp-synchroniser-plugin.helpers";
+import { getCameraLerpPlugin } from "./plugins/camera-lerp-plugin/camera-lerp-plugin.helpers";
+import { getRaycasterPlugin } from "./plugins/raycaster-plugin/raycaster-plugin.helpers";
+import { getHoverPlugin } from "./plugins/hover-plugin/hover-plugin.helpers";
 
 export default class ThreeEntryPoint implements IEntryPoint {
 	private dataStore: DataStore;
@@ -12,13 +16,18 @@ export default class ThreeEntryPoint implements IEntryPoint {
 	public plugins: any[];
 	public interactive: boolean = true;
 
-	constructor(canvas: HTMLCanvasElement, sceneConfig: ISceneConfig, plugins: any[], scenePlugins: any[]) {
+	constructor(canvas: HTMLCanvasElement, sceneConfig: ISceneConfig, eventPlugins: any[], scenePlugins: any[]) {
 		this.dataStore = new DataStore;
 
 		this.canvas = canvas;
 		this.sceneConfig = sceneConfig;
 		this.manager = new SceneManager(canvas, sceneConfig, this.dataStore, scenePlugins);
-		this.plugins = plugins.map(Plugin => new Plugin(this.dataStore));
+		this.plugins = eventPlugins.map(Plugin => new Plugin(this.dataStore));
+
+		this.initCameraLerpSynchroniserPlugin(
+			this.plugins,
+			this.manager.plugins
+		);
 
 		this.bindEventListeners();
 		this.render();
@@ -44,4 +53,20 @@ export default class ThreeEntryPoint implements IEntryPoint {
 		requestAnimationFrame(() => { this.render() });
 		this.manager.update();
 	};
+
+	private initCameraLerpSynchroniserPlugin(eventPlugins: any[], scenePlugins: any[]): void {
+		const synchroniser = getCameraLerpSynchroniserPlugin(scenePlugins);
+
+		if (synchroniser) {
+			const lerp = getCameraLerpPlugin(scenePlugins);
+			const raycaster = getRaycasterPlugin(eventPlugins);
+
+			// The synchroniser needs lerp and raycaster at minimum to provide value.
+			if (lerp && raycaster) {
+				synchroniser.lerp = lerp;
+				synchroniser.raycaster = raycaster;
+				synchroniser.hover = getHoverPlugin(eventPlugins);
+			}
+		}
+	}
 };

--- a/package/utils/zoom.ts
+++ b/package/utils/zoom.ts
@@ -6,6 +6,25 @@ import { IOrthographicCameraConfig, IPerspectiveCameraConfig } from "../types";
 
 import { IDataStore } from "../data-store/data-store.types";
 
+// Coordinate 0, 0, 0
+const OOO = new Vector3;
+
+export const getAspectRatioFromControls = (controls: MapControls): number => {
+  // Determine aspect ratio
+
+  let container = undefined;
+
+  if (controls.domElement instanceof Document) {
+    container = controls.domElement.body;
+  }
+
+  if (controls.domElement instanceof HTMLElement) {
+    container = controls.domElement
+  }
+
+  return container ? container.clientWidth / container.clientHeight : 1;
+}
+
 /**
  * This function will adjust the camera and controls to zoom in and center on a set of objects.
  * 
@@ -80,9 +99,6 @@ export const setCameraToConfig = (
   // Stop any animations
   setZoomProps(undefined);
 
-  // Coordinate 0, 0, 0
-  const OOO = new Vector3;
-
   camera.position.set(config.position.x, config.position.y, config.position.z);
   camera.lookAt(OOO);
 
@@ -117,18 +133,23 @@ export const setCameraToConfig = (
   camera.updateProjectionMatrix();
 }
 
-export const getAspectRatioFromControls = (controls: MapControls): number => {
-  // Determine aspect ratio
+export const zoomCameraToConfig = (
+  store: IDataStore,
+  config: IOrthographicCameraConfig | IPerspectiveCameraConfig
+) => {
+  const origin = new Object3D();
+  origin.position.set(config.position.x, config.position.y, config.position.z);
 
-  let container = undefined;
+  zoomCameraToSelection([origin], store);
 
-  if (controls.domElement instanceof Document) {
-    container = controls.domElement.body;
+  // Identify type of config
+  if ((config as IOrthographicCameraConfig).frustumSize) {
+    let c = config as IOrthographicCameraConfig;
+
+    const props = store.get(constants.store.zoomProps);
+    store.set(constants.store.zoomProps, {
+      ...props,
+      frustum: c.frustumSize
+    });
   }
-
-  if (controls.domElement instanceof HTMLElement) {
-    container = controls.domElement
-  }
-
-  return container ? container.clientWidth / container.clientHeight : 1;
 }


### PR DESCRIPTION
This PR "glues" together the `camera-lerp`, `raycaster` & `hover`-plugin by providing an additional plugin that checks if the `camera-lerp` plugin is currently animating from `A` to `B`.

If it is, the following happens:
- trigger `raycaster` to update the intersecting object in the datastore.
- trigger `hover` to execute relevant hover bindings based on new intersection.

This plugin has to be instantiated outside of the usual plugin definitions due to its reliance on actual anonymous plugin class instances (`IHoverPlugin`) rather than instances of the exposed plugins (`HoverPlugin`) themselves. This is what the `*.helpers.ts` files are for.

The updated intersection also catches the scenario where a click event is fired after lerp'ing without any mouse movement triggering an update of the intersection thus avoiding unwanted "ghost" clicks.